### PR TITLE
Implemented basic drivetrain with Xbox controls

### DIFF
--- a/src/main/java/frc7913/robot/RobotContainer.kt
+++ b/src/main/java/frc7913/robot/RobotContainer.kt
@@ -1,10 +1,14 @@
 package frc7913.robot
 
+import edu.wpi.first.wpilibj.XboxController
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard
 import edu.wpi.first.wpilibj2.command.Command
+import edu.wpi.first.wpilibj2.command.Commands
 import edu.wpi.first.wpilibj2.command.PrintCommand
+import edu.wpi.first.wpilibj2.command.button.CommandXboxController
 import frc7913.robot.commands.ExampleCommand
+import frc7913.robot.subsystems.DriveTrain
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -42,6 +46,7 @@ object RobotContainer {
 
     init
     {
+        XboxController = CommandXboxController(TODO("Determine port for XboxController"))
         configureButtonBindings()
         SmartDashboard.putData("Auto choices", autoModeChooser)
     }
@@ -53,7 +58,16 @@ object RobotContainer {
      * and then passing it to a [JoystickButton][edu.wpi.first.wpilibj2.command.button.JoystickButton].
      */
     private fun configureButtonBindings() {
-        // TODO: Add button to command mappings here.
-        //       See https://docs.wpilib.org/en/stable/docs/software/commandbased/binding-commands-to-triggers.html
+        // Add button to command mappings here.
+        //  See https://docs.wpilib.org/en/stable/docs/software/commandbased/binding-commands-to-triggers.html
+
+        DriveTrain.defaultCommand = Commands.run(
+            { DriveTrain.driveTrain.tankDrive(-XboxController.leftY, -XboxController.rightY) },
+            DriveTrain
+        )
+
+        XboxController.a().onTrue(PrintCommand("A Button Pressed"))
     }
 }
+
+lateinit var XboxController: CommandXboxController

--- a/src/main/java/frc7913/robot/subsystems/DriveTrain.kt
+++ b/src/main/java/frc7913/robot/subsystems/DriveTrain.kt
@@ -1,0 +1,30 @@
+package frc7913.robot.subsystems
+
+import edu.wpi.first.wpilibj.drive.DifferentialDrive
+import edu.wpi.first.wpilibj.motorcontrol.MotorControllerGroup
+import edu.wpi.first.wpilibj.motorcontrol.PWMVictorSPX
+import edu.wpi.first.wpilibj2.command.SubsystemBase
+
+object DriveTrain : SubsystemBase() {
+
+    private val leftLead = PWMVictorSPX(TODO("Front left drivetrain motor port unknown"))
+    private val leftFollow = PWMVictorSPX(TODO("Rear left drivetrain motor port unknown"))
+    private val leftSide = MotorControllerGroup(leftLead, leftFollow)
+
+    private val rightLead = PWMVictorSPX(TODO("Front right drivetrain motor port unknown"))
+    private val rightFollow = PWMVictorSPX(TODO("Rear right drivetrain motor port unknown"))
+    private val rightSide = MotorControllerGroup(rightLead, rightFollow)
+
+    init {
+        leftSide.inverted = TODO("Unknown if left side of drivetrain should be inverted")
+        rightSide.inverted = TODO("Unknown if right side of drivetrain should be inverted")
+    }
+
+    val driveTrain = DifferentialDrive(leftSide, rightSide)
+
+    init {
+        driveTrain.isSafetyEnabled = true
+        driveTrain.expiration = 0.1
+        driveTrain.setMaxOutput(0.6)
+    }
+}


### PR DESCRIPTION
DriveTrain is a Subsystem object that initializes all of its necessary motors and configures a DifferentialDrive driveTrain from there. 
RobotContainer.kt now has a lateinit global variable called XboxController, which is initialized in the RobotContainer init, notably before calling RobotContainer.configureButtonBindings 
This function configures the default command for the DriveTrain as tank drive based on the XboxController left and right sticks. I also made it print a message when the A Button is pressed, for testing purposes 
There are a number of TODO statements throughout because I couldn't be sure of port numbers. So this should not, in its current state, run properly